### PR TITLE
Fix universal components setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
     "relay-compiler": "relay-compiler --src client --schema server/graphql/schema.graphql",
     "relay-compiler:watch": "relay-compiler --src client --schema server/graphql/schema.graphql --watch",
     "update-schema": "babel-node ./scripts/updateSchema.js",
-    "build": "npm run clean && npm run relay-compiler && npm run build:common && npm run build:copy-files && npm run build:server",
-    "build:copy-files": "cp -R client build/client && cp -R webpack build/webpack",
+    "build": "npm run clean && npm run relay-compiler && npm run build:common && npm run build:server && npm run build:webpack && npm run build:client",
     "build:common": "babel -d ./build/common/ ./common -s --copy-files",
     "build:server": "babel -d ./build/server/ ./server -s --copy-files",
+    "build:webpack": "babel -d ./build/webpack ./webpack -s --copy-files",
+    "build:client": "cp -R ./client ./build/client && webpack --json > ./build/server/render/clientStats.json --config ./build/webpack/client.prod.js && webpack --json > ./build/server/render/serverStats.json --config ./build/webpack/server.prod.js",
     "build-langs": "babel-node ./i18n/bundleMessages.js"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "relay-compiler": "relay-compiler --src client --schema server/graphql/schema.graphql",
     "relay-compiler:watch": "relay-compiler --src client --schema server/graphql/schema.graphql --watch",
     "update-schema": "babel-node ./scripts/updateSchema.js",
-    "build": "npm run clean && npm run relay-compiler && npm run build:common && npm run build:client && npm run build:server && cp -R client build/clientUncompiled && cp -R webpack build/webpack",
-    "build:client": "babel -d ./build/client/ ./client -s --copy-files",
+    "build": "npm run clean && npm run relay-compiler && npm run build:common && npm run build:copy-files && npm run build:server",
+    "build:copy-files": "cp -R client build/client && cp -R webpack build/webpack",
     "build:common": "babel -d ./build/common/ ./common -s --copy-files",
     "build:server": "babel -d ./build/server/ ./server -s --copy-files",
     "build-langs": "babel-node ./i18n/bundleMessages.js"

--- a/server/render/setup.js
+++ b/server/render/setup.js
@@ -53,19 +53,15 @@ export default function setup(app, done) {
   } else {
     log('production config')
     const clientConfig = require('../../webpack/client.prod')
-    const serverConfig = require('../../webpack/server.prod')
     const publicPath = clientConfig.output.publicPath
     const outputPath = clientConfig.output.path
 
-    webpack([clientConfig, serverConfig]).run((err, stats) => {
-      log('build finished')
-      const clientStats = stats.toJson().children[0]
-      const serverRender = require('../../buildClientSSR/main.js').default
+    const clientStats = require('./clientStats.json')
+    const serverRender = require('../../buildClientSSR/main.js').default
 
-      app.use(publicPath, express.static(outputPath))
-      app.use(serverRender({ clientStats }))
+    app.use(publicPath, express.static(outputPath))
+    app.use(serverRender({ clientStats }))
 
-      done()
-    })
+    done()
   }
 }

--- a/server/render/setup.js
+++ b/server/render/setup.js
@@ -33,6 +33,7 @@ export default function setup(app, done) {
   }))
 
   if (DEV) {
+    log('development config')
     const clientConfig = require('../../webpack/client.dev')
     const serverConfig = require('../../webpack/server.dev')
     const webpackDevMiddleware = require('webpack-dev-middleware')
@@ -50,12 +51,14 @@ export default function setup(app, done) {
 
     compiler.plugin('done', done)
   } else {
+    log('production config')
     const clientConfig = require('../../webpack/client.prod')
     const serverConfig = require('../../webpack/server.prod')
     const publicPath = clientConfig.output.publicPath
     const outputPath = clientConfig.output.path
 
     webpack([clientConfig, serverConfig]).run((err, stats) => {
+      log('build finished')
       const clientStats = stats.toJson().children[0]
       const serverRender = require('../../buildClientSSR/main.js').default
 

--- a/webpack/client.prod.js
+++ b/webpack/client.prod.js
@@ -8,7 +8,7 @@ module.exports = {
   name: 'client',
   target: 'web',
   devtool: 'source-map',
-  entry: [path.resolve(__dirname, '../clientUncompiled/index.js')],
+  entry: [path.resolve(__dirname, '../client/index.js')],
   output: {
     filename: '[name].[chunkhash].js',
     chunkFilename: '[name].[chunkhash].js',


### PR DESCRIPTION
- Removed unnecessary babel compile of client files
- Use uncompiled client files instead
- Run webpack client build during build step instead of inside the servers render.js to save server load

Closes #91 